### PR TITLE
Remove projectPath as it causes trouble with Unity

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/unity3d/Unity3dBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/unity3d/Unity3dBuilder.java
@@ -247,9 +247,10 @@ public class Unity3dBuilder extends Builder {
         finalArgLine = Util.replaceMacro(finalArgLine, vars);
         finalArgLine = Util.replaceMacro(finalArgLine, buildVariables);
 
-        if (!finalArgLine.contains("-projectPath")) {
+        // Unity does take the PWD as project path. Jenkins changes the PWD to the workspace in 2.150.3
+        /*if (!finalArgLine.contains("-projectPath")) {
             args.add("-projectPath", moduleRootRemote);
-        }
+        }*/
 
         args.add(QuotedStringTokenizer.tokenize(finalArgLine));
         return args;


### PR DESCRIPTION
Unity already uses the PWD as project path. Look at my comment